### PR TITLE
fix cronjob command

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ this.$api.get('plugin-janitor/cleancache')
 
 Set a `secret` in your config.php file and call the janitor api with secret in a crobjob like this. This way you do not need the Kirby API to authentificate.
 ```php
-wget https://devkit.bnomei.com/plugin-janitor/cleancache/e9fe51f94eadabf54dbf2fbbd57188b9abee436e --delete-after
+wget https://devkit.bnomei.com/plugin-janitor/clear/e9fe51f94eadabf54dbf2fbbd57188b9abee436e --delete-after
 // or
-curl -s https://devkit.bnomei.com/plugin-janitor/cleancache/e9fe51f94eadabf54dbf2fbbd57188b9abee436e > /dev/null
+curl -s https://devkit.bnomei.com/plugin-janitor/clear/e9fe51f94eadabf54dbf2fbbd57188b9abee436e > /dev/null
 ```
 
 ## Dependencies


### PR DESCRIPTION
I couldn't get the `...plugin-janitor/cleancache/...` cronjob to run. It always returned a 404 error. But when I changed it to any job name found in the plugins index.php file such as `...plugin-janitor/clear/...` or `..clean` or `..flush`, it returned a successful 200. I'm thinking the `cleancache` command via cron wasn't right and suggest an update to the docs.